### PR TITLE
chore(ci): integrate Secret Manager for PORTAL_AUTH_TOKEN

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,3 +1,4 @@
+```yaml
 # =============================================================================
 # Cloud Build Configuration - FAANG-Grade CI/CD Pipeline
 # =============================================================================
@@ -24,6 +25,8 @@ availableSecrets:
   secretManager:
     - versionName: projects/${PROJECT_ID}/secrets/PORTAL_WORKLOADS_TFVARS/versions/latest
       env: TFVARS_WORKLOADS
+    - versionName: projects/${PROJECT_ID}/secrets/PORTAL_AUTH_TOKEN/versions/latest
+      env: PORTAL_AUTH_TOKEN
 
 steps:
   # ==========================================================================
@@ -44,9 +47,9 @@ steps:
     args:
       - '-c'
       - |
-        if [ -n "$_SNYK_TOKEN" ]; then
+        if [ -n "$ _SNYK_TOKEN" ]; then
           npm install -g snyk
-          snyk auth "$_SNYK_TOKEN"
+          snyk auth "$ _SNYK_TOKEN"
           snyk test --severity-threshold=high frontend/
           snyk test --severity-threshold=high backend/
         else
@@ -309,7 +312,7 @@ steps:
       - '--platform=managed'
       - '--no-allow-unauthenticated'
       - '--service-account=portal-backend@${PROJECT_ID}.iam.gserviceaccount.com'
-      - '--set-env-vars=ENVIRONMENT=staging,GCP_PROJECT_ID=${PROJECT_ID}'
+      - '--set-env-vars=ENVIRONMENT=staging,GCP_PROJECT_ID=${PROJECT_ID},PORTAL_AUTH_TOKEN=${PORTAL_AUTH_TOKEN}'
       - '--min-instances=1'
       - '--max-instances=10'
       - '--memory=512Mi'
@@ -378,3 +381,5 @@ tags:
   - 'gcp-cloud'
   - 'portal'
   - 'ci-cd'
+
+```


### PR DESCRIPTION
Summary:\n- Add PORTAL_AUTH_TOKEN to Cloud Build  so the token is injected from Secret Manager at build/deploy time.\n- Pass  as an env var to Cloud Run staging deploy.\n- Backend  now fetches  via the existing GSM helper (when available).\n\nFiles changed: , \n\nHow to test locally:\n1) Create secret in GSM and grant access to Cloud Build and runtime service accounts (see issue #70).\n2) Run Cloud Build or a dry-run: \n3) Verify Cloud Run service receives  in environment or backend reads via GSM helper.\n\nNext steps (owner actions):\n- Create the secret  in Secret Manager and grant  to Cloud Build and runtime SAs.\n- Rotate compromised credential referenced in #73 and store the new value in Secret Manager.\n- After rotation, follow runbook in #74 to purge history if needed.\n\nLinked issues: #70, #73, #74\n